### PR TITLE
Remove feature gate for `Deref<Target=[T]>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,6 @@ required-features = ["serde_support", "serde_json_support"]
 
 [features]
 std = []
-deref_to_slice = []
 default = ["std"]
 serde_support = ["serde"]
 serde_json_support = ["serde_json"]

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Fully `#![no_std]` compatible (with almost no loss of functionality) by setting
 Optional support for serialization and deserialization of the `StaticVec` struct
 via `serde` is available by activating the `serde_support` feature.
 
-`StaticVec` also implements both `Deref` and `DerefMut` to `[T]` if the `deref_to_slice`
-crate feature is enabled.
+StaticVec implements both Deref and DerefMut to [T], which means it provides
+all the existing slice methods, and references to it can be used in contexts
+where [T] is expected.
 
 Contributions/suggestions/etc. very welcome!
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ use core::marker::PhantomData;
 use core::mem::{self, MaybeUninit};
 use core::ops::{Bound::Excluded, Bound::Included, Bound::Unbounded, RangeBounds};
 use core::ptr;
+use core::slice;
 
 mod iterators;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,30 +475,6 @@ impl<T, const N: usize> StaticVec<T, { N }> {
     }
   }
 
-  ///Performs a stable in-place sort of the StaticVec's inhabited area.
-  ///Locally requires that `T` implements [Ord](core::cmp::Ord) to make the sorting possible.
-  #[cfg(feature = "std")]
-  #[doc(cfg(feature = "std"))]
-  #[inline(always)]
-  pub fn sort(&mut self)
-  where T: Ord {
-    self.as_mut_slice().sort();
-  }
-
-  ///Performs an unstable in-place sort of the StaticVec's inhabited area.
-  ///Locally requires that `T` implements [Ord](core::cmp::Ord) to make the sorting possible.
-  #[inline(always)]
-  pub fn sort_unstable(&mut self)
-  where T: Ord {
-    self.as_mut_slice().sort_unstable();
-  }
-
-  ///Reverses the contents of the StaticVec's inhabited area in-place.
-  #[inline(always)]
-  pub fn reverse(&mut self) {
-    self.as_mut_slice().reverse();
-  }
-
   ///Returns a separate, stable-sorted StaticVec of the contents of the
   ///StaticVec's inhabited area without modifying the original data.
   ///Locally requires that `T` implements [Copy](core::marker::Copy) to avoid soundness issues,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,15 +212,16 @@ impl<T, const N: usize> StaticVec<T, { N }> {
   ///Returns a constant reference to a slice of the StaticVec's inhabited area.
   #[inline(always)]
   pub fn as_slice(&self) -> &[T] {
-    unsafe { &*(self.data.get_unchecked(0..self.length) as *const [MaybeUninit<T>] as *const [T]) }
+    // Safety: Self is an array, and is guaranteed that the first `length`
+    // elements are initialized. Therefore this is a valid slice.
+    unsafe { slice::from_raw_parts(self.as_ptr(), self.length) }
   }
 
   ///Returns a mutable reference to a slice of the StaticVec's inhabited area.
   #[inline(always)]
   pub fn as_mut_slice(&mut self) -> &mut [T] {
-    unsafe {
-      &mut *(self.data.get_unchecked_mut(0..self.length) as *mut [MaybeUninit<T>] as *mut [T])
-    }
+    // Safety: See as_slice
+    unsafe { slice::from_raw_parts_mut(self.as_mut_ptr(), self.length) }
   }
 
   ///Returns a constant reference to the element of the StaticVec at `index`, if `index` is within the range `0..length`.

--- a/src/trait_impls.rs
+++ b/src/trait_impls.rs
@@ -6,7 +6,7 @@ use core::fmt::{self, Debug, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::FromIterator;
 use core::mem::MaybeUninit;
-use core::ops::{Index, IndexMut, Range, RangeFull, RangeInclusive, Deref, DerefMut};
+use core::ops::{Deref, DerefMut, Index, IndexMut, Range, RangeFull, RangeInclusive};
 use core::ptr;
 use core::str;
 

--- a/src/trait_impls.rs
+++ b/src/trait_impls.rs
@@ -6,12 +6,9 @@ use core::fmt::{self, Debug, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::FromIterator;
 use core::mem::MaybeUninit;
-use core::ops::{Index, IndexMut, Range, RangeFull, RangeInclusive};
+use core::ops::{Index, IndexMut, Range, RangeFull, RangeInclusive, Deref, DerefMut};
 use core::ptr;
 use core::str;
-
-#[cfg(feature = "deref_to_slice")]
-use core::ops::{Deref, DerefMut};
 
 #[cfg(feature = "std")]
 use alloc::string::String;
@@ -76,7 +73,6 @@ impl<T, const N: usize> Default for StaticVec<T, { N }> {
   }
 }
 
-#[cfg(feature = "deref_to_slice")]
 impl<T, const N: usize> Deref for StaticVec<T, { N }> {
   type Target = [T];
   #[inline(always)]
@@ -85,7 +81,6 @@ impl<T, const N: usize> Deref for StaticVec<T, { N }> {
   }
 }
 
-#[cfg(feature = "deref_to_slice")]
 impl<T, const N: usize> DerefMut for StaticVec<T, { N }> {
   #[inline(always)]
   fn deref_mut(&mut self) -> &mut [T] {

--- a/test/test.rs
+++ b/test/test.rs
@@ -479,13 +479,6 @@ fn retain() {
 }
 
 #[test]
-fn reverse() {
-  let mut v = staticvec![1, 2, 3];
-  v.reverse();
-  assert!(v == [3, 2, 1]);
-}
-
-#[test]
 fn reversed() {
   let v = staticvec![1, 2, 3].reversed();
   assert!(v == [3, 2, 1]);
@@ -501,23 +494,8 @@ fn set_len() {
 
 #[cfg(feature = "std")]
 #[test]
-fn sort() {
-  let mut v = staticvec![-5, 4, 1, -3, 2];
-  v.sort();
-  assert!(v == [-5, -3, 1, 2, 4]);
-}
-
-#[cfg(feature = "std")]
-#[test]
 fn sorted() {
   let v = staticvec![-5, 4, 1, -3, 2].sorted();
-  assert!(v == [-5, -3, 1, 2, 4]);
-}
-
-#[test]
-fn sort_unstable() {
-  let mut v = staticvec![-5, 4, 1, -3, 2];
-  v.sort_unstable();
   assert!(v == [-5, -3, 1, 2, 4]);
 }
 


### PR DESCRIPTION
Propose that the feature gate on `Deref<Target=[T]>` is removed, and that duplicate methods that already exist on `[T]` are removed. It's an common pattern for array-like data structures to include this deref (for example, `Vec`, `String` (to `str`), and it's useful to have access to the numerous methods that slices provide, all of which don't require knowledge of the underlying capacity `N` and therefore don't benefit from a specialized implementation (for instance, there's no reason to have our own implementation of `first` and `last`).

I'd like to get this resolved before continuing work on #11, as much of the new code in that pull request depends on slice-like methods, especially `get_unchecked`.

- Removes `deref_to_slice` feature
- Also updates `as_slice` to use `from_raw_parts` rather than a series of `as` casts
- Updates reference to `Deref` in README

Part of a series of pull requests that break down #11 into simpler parts