### PR TITLE
Updates to Read and Write implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![feature(exact_size_is_empty)]
 #![feature(trusted_len)]
 #![feature(slice_partition_dedup)]
+#![feature(read_initializer)]
 
 //Literally just for stable-sort.
 #[cfg(any(feature = "std", rustdoc))]

--- a/src/trait_impls.rs
+++ b/src/trait_impls.rs
@@ -455,6 +455,9 @@ impl<const N: usize> Write for StaticVec<u8, { N }> {
   fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
     let old_length = self.length;
     for buf in bufs {
+      if self.is_full() {
+        break;
+      }
       self.extend_from_slice(buf);
     }
     Ok(self.length - old_length)

--- a/src/trait_impls.rs
+++ b/src/trait_impls.rs
@@ -330,6 +330,14 @@ impl_partial_ord_with_as_slice_against_slice!([T1], &mut StaticVec<T2, { N }>);
 impl_partial_ord_with_as_slice_against_slice!(&[T1], StaticVec<T2, { N }>);
 impl_partial_ord_with_as_slice_against_slice!(&mut [T1], StaticVec<T2, { N }>);
 
+/// Read from a [`StaticVec`]. This implementation reads from the `StaticVec`
+/// by copying bytes into the destination buffers, then shifting the remaining
+/// bytes over. This might be inefficient for your needs; consider using
+/// [`Cursor`] or [`[T] as Read`][slice-read] for more efficient
+/// ways to read out of a `StaticVec` without mutating it.
+///
+/// [`Cursor`]: https://doc.rust-lang.org/stable/std/io/struct.Cursor.html
+/// [slice-read]: https://doc.rust-lang.org/stable/std/primitive.slice.html#impl-Read]
 #[cfg(feature = "std")]
 impl<const N: usize> Read for StaticVec<u8, { N }> {
   #[inline]


### PR DESCRIPTION
- All io code is now safe and based on slice copying
    - Rationale: The assumption is that the optimizer can remove all the bounds checking after inlining, since all of the provided bounds are plainly inside the buffers
    - The only remaining "semantically unsafe" code is direct writes to `self.length`, for which I've provided `// Safety:` comments
- `read` no longer uses `drain`, to avoid its complexity and extra copying
    - Drain copies data to a local `StaticVec<u8, N>` on the stack. This is a very unnecessary copy and use of stack memory, especially if the `StaticVec` is very large. Additionally, the `drain` logic is made complicated, because it supports draining from the inside of the vector; our needs are only to copy from the front, then shift the array contents back.
- Added `read_to_end` and `read_to_string`
- `read_vectored` no longer excessively performs interior copies
- Added `Read::initializer`
- `write_all` no longer writes unless it knows it will succeed
    - `write_all` provides no contractural guarantees about how many bytes were written if it returns an error, so there's no reason to write if we know we'll return an error.
- Replaced many uses of `unwrap` with `?`
- Added `io::` namespacing for clarity of generically-named types like `Error`
- Added tests