### PR TITLE
Updated `Clone` implementation

### DIFF
--- a/benchmark/smallvec_full_suite.rs
+++ b/benchmark/smallvec_full_suite.rs
@@ -311,6 +311,15 @@ fn bench_clone(b: &mut Bencher) {
 }
 
 #[bench]
+fn bench_trivial_clone(b: &mut Bencher) {
+  let v: StaticVec<u32, { 200 }> = (50..150).collect();
+
+  b.iter(move || {
+    let _v2 = black_box(v.clone());
+  })
+}
+
+#[bench]
 fn bench_clone_from_shorter(b: &mut Bencher) {
   // We create some vectors with semi-random lengths to provoke
   // different behaviors in the underlying Vec::clone_from. This allows us to

--- a/benchmark/smallvec_full_suite.rs
+++ b/benchmark/smallvec_full_suite.rs
@@ -14,7 +14,7 @@ use staticvec::*;
 
 extern crate test;
 
-use test::{Bencher, black_box};
+use test::{black_box, Bencher};
 
 const VEC_SIZE: usize = 16;
 const SPILLED_SIZE: usize = 100;
@@ -303,9 +303,7 @@ fn vec_bench_macro_from_list(b: &mut Bencher) {
 
 #[bench]
 fn bench_clone(b: &mut Bencher) {
-  let v: StaticVec<Vec<u32>, {200}> = (0..100)
-    .map(|i| (0..i).collect())
-    .collect();
+  let v: StaticVec<Vec<u32>, { 200 }> = (0..100).map(|i| (0..i).collect()).collect();
 
   b.iter(move || {
     let _v2 = black_box(v.clone());
@@ -318,9 +316,7 @@ fn bench_clone_from_shorter(b: &mut Bencher) {
   // different behaviors in the underlying Vec::clone_from. This allows us to
   // demonstrate the advantage of using an underlying clone_from over a raw
   // clone.
-  let src: StaticVec<Vec<u32>, {200}> = (0..50)
-    .map(|i| (0..i % 7).collect())
-    .collect();
+  let src: StaticVec<Vec<u32>, { 200 }> = (0..50).map(|i| (0..i % 7).collect()).collect();
 
   b.iter(move || {
     // TODO: find a way to make the bencher not include the time required to
@@ -328,14 +324,16 @@ fn bench_clone_from_shorter(b: &mut Bencher) {
     // to make sure dst is in the same state before each bench run. We don't
     // want to clone it, either, because part of the test includes the
     // allocations into `vec`
-    let mut dst: StaticVec<Vec<u32>, {200}> = black_box((0..100)
-    .map(|i| {
-      // ensure we have enouch capacity to benefit from clone_from
-      let mut vec = Vec::with_capacity(20);
-      vec.extend(1..1+(i % 11));
-      vec
-    })
-    .collect());
+    let mut dst: StaticVec<Vec<u32>, { 200 }> = black_box(
+      (0..100)
+        .map(|i| {
+          // ensure we have enouch capacity to benefit from clone_from
+          let mut vec = Vec::with_capacity(20);
+          vec.extend(1..1 + (i % 11));
+          vec
+        })
+        .collect(),
+    );
 
     dst.clone_from(&src);
   });
@@ -347,9 +345,7 @@ fn bench_clone_from_longer(b: &mut Bencher) {
   // different behaviors in the underlying Vec::clone_from. This allows us to
   // demonstrate the advantage of using an underlying clone_from over a raw
   // clone.
-  let src: StaticVec<Vec<u32>, {200}> = (0..100)
-    .map(|i| (0..i % 7).collect())
-    .collect();
+  let src: StaticVec<Vec<u32>, { 200 }> = (0..100).map(|i| (0..i % 7).collect()).collect();
 
   b.iter(move || {
     // TODO: find a way to make the bencher not include the time required to
@@ -357,14 +353,16 @@ fn bench_clone_from_longer(b: &mut Bencher) {
     // to make sure dst is in the same state before each bench run. We don't
     // want to clone it, either, because part of the test includes the
     // allocations into `vec`
-    let mut dst: StaticVec<Vec<u32>, {200}> = black_box((0..50)
-    .map(|i| {
-      // ensure we have enouch capacity to benefit from clone_from
-      let mut vec = Vec::with_capacity(20);
-      vec.extend(1..1+(i % 11));
-      vec
-    })
-    .collect());
+    let mut dst: StaticVec<Vec<u32>, { 200 }> = black_box(
+      (0..50)
+        .map(|i| {
+          // ensure we have enouch capacity to benefit from clone_from
+          let mut vec = Vec::with_capacity(20);
+          vec.extend(1..1 + (i % 11));
+          vec
+        })
+        .collect(),
+    );
 
     dst.clone_from(&src);
   });

--- a/test/test.rs
+++ b/test/test.rs
@@ -81,8 +81,8 @@ fn clone() {
 
 #[test]
 fn clone_from_shorter() {
-  let src: StaticVec<u32, {20}> = (1..10).collect();
-  let mut dst: StaticVec<u32, {20}> = (0..15).collect();
+  let src: StaticVec<u32, { 20 }> = (1..10).collect();
+  let mut dst: StaticVec<u32, { 20 }> = (0..15).collect();
 
   dst.clone_from(&src);
   assert_eq!(dst, src);
@@ -90,8 +90,8 @@ fn clone_from_shorter() {
 
 #[test]
 fn clone_from_longer() {
-  let src: StaticVec<u32, {20}> = (0..15).collect();
-  let mut dst: StaticVec<u32, {20}> = (1..10).collect();
+  let src: StaticVec<u32, { 20 }> = (0..15).collect();
+  let mut dst: StaticVec<u32, { 20 }> = (1..10).collect();
 
   dst.clone_from(&src);
   assert_eq!(dst, src);

--- a/test/test.rs
+++ b/test/test.rs
@@ -80,6 +80,24 @@ fn clone() {
 }
 
 #[test]
+fn clone_from_shorter() {
+  let src: StaticVec<u32, {20}> = (1..10).collect();
+  let mut dst: StaticVec<u32, {20}> = (0..15).collect();
+
+  dst.clone_from(&src);
+  assert_eq!(dst, src);
+}
+
+#[test]
+fn clone_from_longer() {
+  let src: StaticVec<u32, {20}> = (0..15).collect();
+  let mut dst: StaticVec<u32, {20}> = (1..10).collect();
+
+  dst.clone_from(&src);
+  assert_eq!(dst, src);
+}
+
+#[test]
 fn dedup() {
   let mut vec = staticvec![1, 2, 2, 3, 2];
   vec.dedup();


### PR DESCRIPTION
- Added `clone_from`
- Simplified `clone`
- Added tests
- Added benchmarks

Some benchmark notes:

- Unfortunately, I couldn't figure out a way to create a clone_from benchmark that didn't include initializing the destination `StaticVec` inside of `bencher.iter`; the `Bencher` api doesn't appear to support setup work that must happen once per iteration. Nonetheless, the custom clone_from shows a substantial improvement over the default (~15 µs vs ~20µs for both shorter and longer destinations). Please let me know if you know of a way to fix this.
- The benchmark numbers for `clone` are roughly the same for the updated implementation. 