### PR TITLE
Replace `Index` impls with versions that defer to slice indexing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,6 @@ serde_support = ["serde"]
 serde_json_support = ["serde_json"]
 
 [dev-dependencies]
-cool_asserts = "1.0.0"
 # This is here so we can compare against it in one of the benchmarks.
 arrayvec = "0.5.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ serde_support = ["serde"]
 serde_json_support = ["serde_json"]
 
 [dev-dependencies]
+cool_asserts = "1.0.0"
 # This is here so we can compare against it in one of the benchmarks.
 arrayvec = "0.5.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,7 @@ impl<T, const N: usize> StaticVec<T, { N }> {
   /// Note that, unlike [`slice::get_unchecked_mut`], this method only supports
   /// accessing individual elements via `usize`; it cannot also produce
   /// subslices. To unsafely get a mutable subslice without a bounds check, use
-  /// `vec.as_slice().get_unchecked_mut(a..b)`.
+  /// `vec.as_mut_slice().get_unchecked_mut(a..b)`.
   ///
   /// # Safety
   ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,11 +231,21 @@ impl<T, const N: usize> StaticVec<T, { N }> {
     unsafe { slice::from_raw_parts_mut(self.as_mut_ptr(), self.length) }
   }
 
-  ///Returns a constant reference to the element of the StaticVec at `index`, if `index` is within the range `0..length`.
-  ///No checks are performed to ensure that is the case, so this function is marked `unsafe` and should be used with caution
-  ///only when performance is absolutely paramount.
-  ///# Safety
-  ///It is up to the caller to ensure that `index` is within the appropriate bounds.
+  /// Returns a constant reference to the element of the StaticVec at `index`,
+  /// if `index` is within the range `0..length`. No checks are performed to
+  /// ensure that is the case, so this function is marked `unsafe` and should
+  /// be used with caution only when performance is absolutely paramount.
+  ///
+  /// Note that, unlike [`slice::get_unchecked`], this method only supports
+  /// accessing individual elements via `usize`; it cannot also produce
+  /// subslices. To unsafely get a subslice without a bounds check, use
+  /// `vec.as_slice().get_unchecked(a..b)`.
+  ///
+  /// # Safety
+  ///
+  /// It is up to the caller to ensure that `index` is within the appropriate bounds.
+  ///
+  /// [`slice::get_unchecked`]: https://doc.rust-lang.org/std/primitive.slice.html#method.get_unchecked
   #[inline(always)]
   pub unsafe fn get_unchecked(&self, index: usize) -> &T {
     debug_assert!(
@@ -247,11 +257,21 @@ impl<T, const N: usize> StaticVec<T, { N }> {
     self.data.get_unchecked(index).get_ref()
   }
 
-  ///Returns a mutable reference to the element of the StaticVec at `index`, if `index` is within the range `0..length`.
-  ///No checks are performed to ensure that is the case, so this function is marked `unsafe` and should be used with caution
-  ///only when performance is absolutely paramount.
-  ///# Safety
-  ///It is up to the caller to ensure that `index` is within the appropriate bounds.
+  /// Returns a mutable reference to the element of the StaticVec at `index`,
+  /// if `index` is within the range `0..length`. No checks are performed to
+  /// ensure that is the case, so this function is marked `unsafe` and should
+  /// be used with caution only when performance is absolutely paramount.
+  ///
+  /// Note that, unlike [`slice::get_unchecked_mut`], this method only supports
+  /// accessing individual elements via `usize`; it cannot also produce
+  /// subslices. To unsafely get a mutable subslice without a bounds check, use
+  /// `vec.as_slice().get_unchecked_mut(a..b)`.
+  ///
+  /// # Safety
+  ///
+  /// It is up to the caller to ensure that `index` is within the appropriate bounds.
+  ///
+  /// [`slice::get_unchecked_mut`]: https://doc.rust-lang.org/std/primitive.slice.html#method.get_unchecked_mut
   #[inline(always)]
   pub unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T {
     debug_assert!(

--- a/src/trait_impls.rs
+++ b/src/trait_impls.rs
@@ -9,6 +9,7 @@ use core::mem::MaybeUninit;
 use core::ops::{Deref, DerefMut, Index, IndexMut, Range, RangeFull, RangeInclusive};
 use core::ptr;
 use core::str;
+use core::slice::SliceIndex;
 
 #[cfg(feature = "std")]
 use alloc::string::String;
@@ -200,91 +201,19 @@ impl<T: Hash, const N: usize> Hash for StaticVec<T, { N }> {
   }
 }
 
-impl<T, const N: usize> Index<usize> for StaticVec<T, { N }> {
-  type Output = T;
-  ///Asserts that `index` is less than the current length of the StaticVec,
-  ///and if so returns the value at that position as a constant reference.
+impl<T, I: SliceIndex<[T]>, const N: usize> Index<I> for StaticVec<T, {N}> {
+  type Output = I::Output;
+
   #[inline(always)]
-  fn index(&self, index: usize) -> &Self::Output {
-    assert!(index < self.length);
-    unsafe { self.data.get_unchecked(index).get_ref() }
+  fn index(&self, index: I) -> &Self::Output {
+    self.as_slice().index(index)
   }
 }
 
-impl<T, const N: usize> IndexMut<usize> for StaticVec<T, { N }> {
-  ///Asserts that `index` is less than the current length of the StaticVec,
-  ///and if so returns the value at that position as a mutable reference.
+impl<T, I: SliceIndex<[T]>, const N: usize> IndexMut<I> for StaticVec<T, { N }> {
   #[inline(always)]
-  fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-    assert!(index < self.length);
-    unsafe { self.data.get_unchecked_mut(index).get_mut() }
-  }
-}
-
-impl<T, const N: usize> Index<Range<usize>> for StaticVec<T, { N }> {
-  type Output = [T];
-  ///Asserts that the lower bound of `index` is less than its upper bound,
-  ///and that its upper bound is less than or equal to the current length of the StaticVec,
-  ///and if so returns a constant reference to a slice of elements `index.start..index.end`.
-  #[inline(always)]
-  fn index(&self, index: Range<usize>) -> &Self::Output {
-    assert!(index.start < index.end && index.end <= self.length);
-    unsafe { &*(self.data.get_unchecked(index) as *const [MaybeUninit<T>] as *const [T]) }
-  }
-}
-
-impl<T, const N: usize> IndexMut<Range<usize>> for StaticVec<T, { N }> {
-  ///Asserts that the lower bound of `index` is less than its upper bound,
-  ///and that its upper bound is less than or equal to the current length of the StaticVec,
-  ///and if so returns a mutable reference to a slice of elements `index.start..index.end`.
-  #[inline(always)]
-  fn index_mut(&mut self, index: Range<usize>) -> &mut Self::Output {
-    assert!(index.start < index.end && index.end <= self.length);
-    unsafe { &mut *(self.data.get_unchecked_mut(index) as *mut [MaybeUninit<T>] as *mut [T]) }
-  }
-}
-
-impl<T, const N: usize> Index<RangeFull> for StaticVec<T, { N }> {
-  type Output = [T];
-  ///Returns a constant reference to a slice consisting of `0..self.length`
-  ///elements of the StaticVec, using [as_slice](crate::StaticVec::as_slice) internally.
-  #[inline(always)]
-  fn index(&self, _index: RangeFull) -> &Self::Output {
-    self.as_slice()
-  }
-}
-
-impl<T, const N: usize> IndexMut<RangeFull> for StaticVec<T, { N }> {
-  ///Returns a mutable reference to a slice consisting of `0..self.length`
-  ///elements of the StaticVec, using [as_mut_slice](crate::StaticVec::as_mut_slice) internally.
-  #[inline(always)]
-  fn index_mut(&mut self, _index: RangeFull) -> &mut Self::Output {
-    self.as_mut_slice()
-  }
-}
-
-impl<T, const N: usize> Index<RangeInclusive<usize>> for StaticVec<T, { N }> {
-  type Output = [T];
-  ///Asserts that the lower bound of `index` is less than or equal to its upper bound,
-  ///and that its upper bound is less than the current length of the StaticVec,
-  ///and if so returns a constant reference to a slice of elements `index.start()..=index.end()`.
-  #[allow(clippy::op_ref)]
-  #[inline(always)]
-  fn index(&self, index: RangeInclusive<usize>) -> &Self::Output {
-    assert!(index.start() <= index.end() && index.end() < &self.length);
-    unsafe { &*(self.data.get_unchecked(index) as *const [MaybeUninit<T>] as *const [T]) }
-  }
-}
-
-impl<T, const N: usize> IndexMut<RangeInclusive<usize>> for StaticVec<T, { N }> {
-  ///Asserts that the lower bound of `index` is less than or equal to its upper bound,
-  ///and that its upper bound is less than the current length of the StaticVec,
-  ///and if so returns a mutable reference to a slice of elements `index.start()..=index.end()`.
-  #[allow(clippy::op_ref)]
-  #[inline(always)]
-  fn index_mut(&mut self, index: RangeInclusive<usize>) -> &mut Self::Output {
-    assert!(index.start() <= index.end() && index.end() < &self.length);
-    unsafe { &mut *(self.data.get_unchecked_mut(index) as *mut [MaybeUninit<T>] as *mut [T]) }
+  fn index_mut(&mut self, index: I) -> &mut Self::Output {
+    self.as_mut_slice().index_mut(index)
   }
 }
 

--- a/src/trait_impls.rs
+++ b/src/trait_impls.rs
@@ -5,11 +5,10 @@ use core::cmp::{Eq, Ord, Ordering, PartialEq};
 use core::fmt::{self, Debug, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::FromIterator;
-use core::mem::MaybeUninit;
-use core::ops::{Deref, DerefMut, Index, IndexMut, Range, RangeFull, RangeInclusive};
+use core::ops::{Deref, DerefMut, Index, IndexMut};
 use core::ptr;
-use core::str;
 use core::slice::SliceIndex;
+use core::str;
 
 #[cfg(feature = "std")]
 use alloc::string::String;
@@ -201,7 +200,7 @@ impl<T: Hash, const N: usize> Hash for StaticVec<T, { N }> {
   }
 }
 
-impl<T, I: SliceIndex<[T]>, const N: usize> Index<I> for StaticVec<T, {N}> {
+impl<T, I: SliceIndex<[T]>, const N: usize> Index<I> for StaticVec<T, { N }> {
   type Output = I::Output;
 
   #[inline(always)]

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::all)]
 
-use cool_asserts::assert_panics;
 use staticvec::*;
 
 #[derive(Debug)]
@@ -224,12 +223,15 @@ fn index() {
   assert_eq!(vec[1..=3], [1, 2, 3]);
   assert_eq!(vec[..], [0, 1, 2, 3, 4]);
 
-  // Check bounds checking
-  assert_panics!(vec[10]);
-  assert_panics!(&vec[..10]);
-  assert_panics!(&vec[10..]);
-  assert_panics!(&vec[10..15]);
-  assert_panics!(&vec[1..0]);
+  // TODO: add checks that a failed bounds check results in a panic. Currently
+  // this is untestable, because writing the bad boundary expression (eg,
+  // `vec[10]` or `vec.index(10)`) causes a miri failure before the test can
+  // even run.
+  //
+  // Example test:
+  //
+  // // cool_asserts is a library providing assert_panics
+  // cool_asserts::assert_panics!(vec[10]);
 }
 
 #[test]

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,5 +1,8 @@
 #![allow(clippy::all)]
 
+#[cfg(not(miri))]
+use cool_asserts::assert_panics;
+
 use staticvec::*;
 
 #[derive(Debug)]
@@ -223,15 +226,17 @@ fn index() {
   assert_eq!(vec[1..=3], [1, 2, 3]);
   assert_eq!(vec[..], [0, 1, 2, 3, 4]);
 
-  // TODO: add checks that a failed bounds check results in a panic. Currently
-  // this is untestable, because writing the bad boundary expression (eg,
-  // `vec[10]` or `vec.index(10)`) causes a miri failure before the test can
-  // even run.
-  //
-  // Example test:
-  //
-  // // cool_asserts is a library providing assert_panics
-  // cool_asserts::assert_panics!(vec[10]);
+  // Because this block incldues obviously-violated bounds checks, miri
+  // complains about it
+  #[cfg(not(miri))]
+  {
+    // Check bounds checking
+    assert_panics!(vec[10]);
+    assert_panics!(&vec[..10]);
+    assert_panics!(&vec[10..]);
+    assert_panics!(&vec[10..15]);
+    assert_panics!(&vec[1..0]);
+  }
 }
 
 #[test]

--- a/test/test.rs
+++ b/test/test.rs
@@ -216,7 +216,7 @@ fn get_unchecked_mut() {
 
 #[test]
 fn index() {
-  let vec = staticvec![0u32, 1, 2, 3, 4];
+  let vec = staticvec![0, 1, 2, 3, 4];
   assert_eq!(vec[3], 3);
   assert_eq!(vec[1..4], [1, 2, 3]);
   assert_eq!(vec[1..=1], [1]);

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::all)]
 
+use cool_asserts::assert_panics;
 use staticvec::*;
 
 #[derive(Debug)]
@@ -215,12 +216,20 @@ fn get_unchecked_mut() {
 
 #[test]
 fn index() {
-  let vec = staticvec![0, 1, 2, 3, 4];
+  let vec = staticvec![0u32, 1, 2, 3, 4];
+  assert_eq!(vec[3], 3);
   assert_eq!(vec[1..4], [1, 2, 3]);
   assert_eq!(vec[1..=1], [1]);
   assert_eq!(vec[1..3], [1, 2]);
   assert_eq!(vec[1..=3], [1, 2, 3]);
   assert_eq!(vec[..], [0, 1, 2, 3, 4]);
+
+  // Check bounds checking
+  assert_panics!(vec[10]);
+  assert_panics!(&vec[..10]);
+  assert_panics!(&vec[10..]);
+  assert_panics!(&vec[10..15]);
+  assert_panics!(&vec[1..0]);
 }
 
 #[test]


### PR DESCRIPTION
Rationale: the existing Index implementations don't benefit from compiler knowledge of `N`, so there's no reason not to simply use the existing [`SliceIndex`](https://doc.rust-lang.org/std/slice/trait.SliceIndex.html) based indexing used by `Vec`, `slice`, etc. My version calls `self.as_slice().index(index)`, but a slightly less indirected version would instead do `index.get(self.as_slice())` or `index.get(&self)`

Also updated tests to include assertions of panics on bounds check failure.