### PR TITLE
`Clone` implementation leaks cloned values during a panic

### DIFF
--- a/src/trait_impls.rs
+++ b/src/trait_impls.rs
@@ -5,7 +5,6 @@ use core::cmp::{Eq, Ord, Ordering, PartialEq};
 use core::fmt::{self, Debug, Formatter};
 use core::hash::{Hash, Hasher};
 use core::iter::FromIterator;
-use core::mem::MaybeUninit;
 use core::ops::{Deref, DerefMut, Index, IndexMut};
 use core::ptr;
 use core::slice::SliceIndex;
@@ -48,7 +47,7 @@ impl<T, const N: usize> AsRef<[T]> for StaticVec<T, { N }> {
 impl<T: Clone, const N: usize> Clone for StaticVec<T, { N }> {
   #[inline]
   default fn clone(&self) -> Self {
-    let res = Self::new();
+    let mut res = Self::new();
     for i in 0..self.length {
       // Safety: res and self have the same type, so they're guaranteed to
       // have the same capacity, and push_unchecked will never overflow.

--- a/src/trait_impls.rs
+++ b/src/trait_impls.rs
@@ -48,23 +48,16 @@ impl<T, const N: usize> AsRef<[T]> for StaticVec<T, { N }> {
 impl<T: Clone, const N: usize> Clone for StaticVec<T, { N }> {
   #[inline]
   default fn clone(&self) -> Self {
-    Self {
-      data: {
-        unsafe {
-          let mut data: [MaybeUninit<T>; N] = MaybeUninit::uninit_array();
-          for i in 0..self.length {
-            // Put the clones in a separate stack-allocated array first, so we're
-            // not forced to increment `length` for the result variable one by one in order to
-            // account for the possibility of a `clone` call panicking.
-            data
-              .get_unchecked_mut(i)
-              .write(self.get_unchecked(i).clone());
-          }
-          data
-        }
-      },
-      length: self.length,
+    let res = Self::new();
+    for i in 0..self.length {
+      // Safety: res and self have the same type, so they're guaranteed to
+      // have the same capacity, and push_unchecked will never overflow.
+      // 0 <= i < self.length, so get_unchecked is safe.
+      unsafe {
+        res.push_unchecked(self.get_unchecked(i).clone());
+      }
     }
+    res
   }
 
   #[inline]

--- a/test/test.rs
+++ b/test/test.rs
@@ -207,9 +207,6 @@ fn panicking_clone() {
   let lifespan_tracker = LifespanCounter::default();
   let mut vec1: StaticVec<MaybePanicOnClone, 20> = StaticVec::new();
 
-  // For robustness, we add some non panicking cloners, with a panicking clone
-  // in the middle. This ensures the test is robust even if the clone implementation
-  // does something odd like go in reverse order.
   for _ in 0..5 {
     vec1.push(MaybePanicOnClone::new(&lifespan_tracker, false));
   }

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,13 +1,13 @@
 #![allow(clippy::all)]
 
+use staticvec::*;
+
 use core::cell;
 use std::panic::{self, AssertUnwindSafe};
 
 #[cfg(not(miri))]
 #[cfg(feature = "std")]
 use cool_asserts::assert_panics;
-
-use staticvec::*;
 
 #[derive(Debug, Eq, PartialEq, Default)]
 struct Counter(cell::Cell<u32>);

--- a/test/test.rs
+++ b/test/test.rs
@@ -216,10 +216,9 @@ fn panicking_clone() {
   assert_eq!(lifespan_tracker.init_count(), 6);
   assert_eq!(lifespan_tracker.drop_count(), 0);
 
-  // Attempt to clone the staticvec; this will panic. We don't care how many
-  // instances were created during this clone (an ordinary implementation, with
-  // forward iteration, will clone 5 times before panicking); we only care
-  // that the drop count is the same.
+  // Attempt to clone the staticvec; this will panic. This should result in
+  // 5 successful clones, followed by a panic, followed by 5 drops during
+  // unwinding.
   let result = panic::catch_unwind(AssertUnwindSafe(|| {
     let vec2 = vec1.clone();
     vec2

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,10 +1,78 @@
 #![allow(clippy::all)]
 
-use staticvec::*;
+use core::cell;
+use std::panic::{self, AssertUnwindSafe};
 
 #[cfg(not(miri))]
 #[cfg(feature = "std")]
 use cool_asserts::assert_panics;
+
+use staticvec::*;
+
+#[derive(Debug, Eq, PartialEq, Default)]
+struct Counter(cell::Cell<u32>);
+
+impl Counter {
+  fn increment(&self) {
+    self.0.set(self.0.get() + 1);
+  }
+
+  fn get(&self) -> u32 {
+    self.0.get()
+  }
+}
+
+// Helper struct for ensuring things are correctly dropped. Use the `instance`
+// method to create a LifespanCountingInstance, then use the init_count
+// method to see how many such instances were created (either by clone or by
+// `instance`), and the drop_count method to see how many were dropped.
+// TODO: create a more advanced version of this pattern that checks WHICH
+// elements have been dropped; ie, to ensure that the elements at the end of
+// an array are correctly dropped after a truncate
+#[derive(Debug, Default)]
+struct LifespanCounter {
+  // The number of times an instance was created
+  init_count: Counter,
+
+  // The number of times an instance was dropped
+  drop_count: Counter,
+}
+
+impl LifespanCounter {
+  fn instance(&self) -> LifespanCountingInstance {
+    self.init_count.increment();
+    LifespanCountingInstance { counter: self }
+  }
+
+  fn init_count(&self) -> u32 {
+    self.init_count.get()
+  }
+
+  fn drop_count(&self) -> u32 {
+    self.drop_count.get()
+  }
+}
+
+#[derive(Debug)]
+struct LifespanCountingInstance<'a> {
+  counter: &'a LifespanCounter,
+}
+
+impl<'a> Clone for LifespanCountingInstance<'a> {
+  fn clone(&self) -> Self {
+    self.counter.instance()
+  }
+
+  // We deliberately do not provide a clone_from; we'd rather the default
+  // behavior (drop and replace with a fresh instance) is used, so we can
+  // accurately track clones.
+}
+
+impl<'a> Drop for LifespanCountingInstance<'a> {
+  fn drop(&mut self) {
+    self.counter.drop_count.increment()
+  }
+}
 
 #[derive(Debug)]
 struct Struct {
@@ -98,6 +166,80 @@ fn clone_from_longer() {
   let mut dst: StaticVec<u32, { 20 }> = (1..10).collect();
   dst.clone_from(&src);
   assert_eq!(dst, src);
+}
+
+#[test]
+fn panicking_clone() {
+  // An earlier implementation of clone incorrectly leaked values in the event
+  // of a panicking clone. This test ensures that that does not happen.
+
+  // This struct will, if so configured, panic on a clone. Uses
+  // LifespanCountingInstance to track instantiations and deletions, so that
+  // we can ensure the correct number of drops are happening
+  #[derive(Debug)]
+  struct MaybePanicOnClone<'a> {
+    tracker: LifespanCountingInstance<'a>,
+    should_panic: bool,
+  }
+
+  impl<'a> MaybePanicOnClone<'a> {
+    fn new(counter: &'a LifespanCounter, should_panic: bool) -> Self {
+      Self {
+        tracker: counter.instance(),
+        should_panic,
+      }
+    }
+  }
+
+  impl<'a> Clone for MaybePanicOnClone<'a> {
+    fn clone(&self) -> Self {
+      if self.should_panic {
+        panic!("Clone correctly panicked during a test")
+      } else {
+        Self {
+          tracker: self.tracker.clone(),
+          should_panic: self.should_panic,
+        }
+      }
+    }
+  }
+
+  let lifespan_tracker = LifespanCounter::default();
+  let mut vec1: StaticVec<MaybePanicOnClone, 20> = StaticVec::new();
+
+  // For robustness, we add some non panicking cloners, with a panicking clone
+  // in the middle. This ensures the test is robust even if the clone implementation
+  // does something odd like go in reverse order.
+  for _ in 0..5 {
+    vec1.push(MaybePanicOnClone::new(&lifespan_tracker, false));
+  }
+  vec1.push(MaybePanicOnClone::new(&lifespan_tracker, true));
+
+  // Sanity check: we've created 6 instances and dropped none of them
+  assert_eq!(lifespan_tracker.init_count(), 6);
+  assert_eq!(lifespan_tracker.drop_count(), 0);
+
+  // Attempt to clone the staticvec; this will panic. We don't care how many
+  // instances were created during this clone (an ordinary implementation, with
+  // forward iteration, will clone 5 times before panicking); we only care
+  // that the drop count is the same.
+  let result = panic::catch_unwind(AssertUnwindSafe(|| {
+    let vec2 = vec1.clone();
+    vec2
+  }));
+
+  // Ensure that a panic did occur
+  assert!(result.is_err());
+
+  // At this point, 5 instances should have been created and dropped in the
+  // aborted clone
+  assert_eq!(lifespan_tracker.init_count(), 11);
+  assert_eq!(lifespan_tracker.drop_count(), 5);
+
+  drop(vec1);
+
+  assert_eq!(lifespan_tracker.init_count(), 11);
+  assert_eq!(lifespan_tracker.drop_count(), 11);
 }
 
 #[test]


### PR DESCRIPTION
The current implementation of clone, which attempts to optimize writes to `self.length` by deferring them until the end, leaks memory if a clone panics. This occurs because `MaybeUninit<T>` doesn't run destructors when it's dropped, because it can't know whether or not it's initialized. I've added a test demonstrating this behavior, and fixed the clone implementation.

Feel free to replace my clone implementation with one that is optimized to your satisfaction; I only added it so that this pull request would pass CI.