### PR TITLE
Do not require StaticVec::{staticvec, StaticVec} to be in scope for t…

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -20,7 +20,7 @@ macro_rules! staticvec {
     $crate::utils::new_from_value::<_, $n>($val)
   };
   ($($val:expr),* $(,)*) => {
-    StaticVec::<_, {0$(+staticvec!(@put_one $val))*}>::new_from_array([$($val),*])
+    staticvec::StaticVec::<_, {0$(+staticvec::staticvec!(@put_one $val))*}>::new_from_array([$($val),*])
   };
 }
 


### PR DESCRIPTION
…he macro staticvec::staticvec! to work

Fix #23 