### PR TITLE
Optimize `StaticVecIntoIter`

### DIFF
--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -248,8 +248,8 @@ impl<T, const N: usize> StaticVecIntoIter<T, N> {
     unsafe {
       format!(
         "Current value of element at `start`: {:?}\nCurrent value of element at `end`: {:?}",
-        (self.data.as_ptr() as *const T).add(self.start),
-        (self.data.as_ptr() as *const T).add(self.end - 1)
+        &*(self.data.as_ptr() as *const T).add(self.start),
+        &*(self.data.as_ptr() as *const T).add(self.end - 1)
       )
     }
   }

--- a/src/iterators.rs
+++ b/src/iterators.rs
@@ -270,7 +270,7 @@ impl<T, const N: usize> Iterator for StaticVecIntoIter<T, N> {
     match self.end - self.start {
       0 => None,
       _ => {
-        let res = Some(unsafe { self.data.get_unchecked(self.start).read() });
+        let res = Some(unsafe { (self.data.as_ptr() as *const T).add(self.start).read() });
         self.start += 1;
         res
       }
@@ -291,7 +291,7 @@ impl<T, const N: usize> DoubleEndedIterator for StaticVecIntoIter<T, N> {
       0 => None,
       _ => {
         self.end -= 1;
-        Some(unsafe { self.data.get_unchecked(self.end).read() })
+        Some(unsafe { (self.data.as_ptr() as *const T).add(self.end).read() })
       }
     }
   }

--- a/src/trait_impls.rs
+++ b/src/trait_impls.rs
@@ -490,14 +490,14 @@ impl<T, const N: usize> IntoIterator for StaticVec<T, N> {
     let mut iter = StaticVecIntoIter {
       start: 0,
       end: old_length,
-      data: MaybeUninit::uninit_array(),
+      data: Self::new_data_uninit(),
     };
 
     // Copy the inhabited part of self into the iterator
     unsafe {
       self
         .as_ptr()
-        .copy_to_nonoverlapping(iter.data[0].as_mut_ptr(), old_length)
+        .copy_to_nonoverlapping(iter.data.as_mut_ptr() as *mut T, old_length)
     }
 
     iter

--- a/src/trait_impls.rs
+++ b/src/trait_impls.rs
@@ -483,24 +483,24 @@ impl<T, const N: usize> IntoIterator for StaticVec<T, N> {
   fn into_iter(mut self) -> Self::IntoIter {
     let old_length = self.length;
 
-    // This prevents the values from being dropped locally, now that they've
-    // been copied into the iterator
+    // This prevents the values from being dropped locally, since they're
+    // being copied into the iterator.
     self.length = 0;
 
-    let mut iter = StaticVecIntoIter {
+    StaticVecIntoIter {
       start: 0,
       end: old_length,
-      data: Self::new_data_uninit(),
-    };
-
-    // Copy the inhabited part of self into the iterator
-    unsafe {
-      self
-        .as_ptr()
-        .copy_to_nonoverlapping(iter.data.as_mut_ptr() as *mut T, old_length)
+      data: {
+        // Copy the inhabited part of self into the iterator.
+        let mut data = Self::new_data_uninit();
+        unsafe {
+          self
+            .as_ptr()
+            .copy_to_nonoverlapping(data.as_mut_ptr() as *mut T, old_length)
+        };
+        data
+      },
     }
-
-    iter
   }
 }
 


### PR DESCRIPTION
- Store a `[MaybeUninit<T>; N]` instead of `StaticVec<T, N>` to prevent
  storing `self.length` unnecessarily
- Copy only the inhabited part of self into `StaticVecIntoIter` when
  creating it