### PR TITLE
Implement StaticVecIterConst and StaticVecIterMut in terms of core::slice::{Iter, IterMut}

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 #![feature(maybe_uninit_ref)]
 #![feature(maybe_uninit_uninit_array)]
 #![cfg_attr(feature = "std", feature(read_initializer))]
+#![feature(slice_iter_mut_as_slice)]
 #![feature(slice_partition_dedup)]
 #![feature(specialization)]
 #![feature(trusted_len)]
@@ -37,7 +38,6 @@ use core::cmp::{Ord, PartialEq};
 use core::intrinsics;
 #[doc(hidden)]
 pub use core::iter::FromIterator;
-use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::ops::{
   Add, Bound::Excluded, Bound::Included, Bound::Unbounded, Div, Mul, RangeBounds, Sub,
@@ -728,12 +728,7 @@ impl<T, const N: usize> StaticVec<T, N> {
   #[inline(always)]
   pub fn iter_mut(&mut self) -> StaticVecIterMut<T, N> {
     StaticVecIterMut {
-      start: self.as_mut_ptr(),
-      end: match intrinsics::size_of::<T>() {
-        0 => (self.as_mut_ptr() as *mut u8).wrapping_add(self.length) as *mut T,
-        _ => unsafe { self.mut_ptr_at_unchecked(self.length) },
-      },
-      marker: PhantomData,
+      iter: slice_from_raw_parts_mut(self.as_mut_ptr(), self.length).iter_mut(),
     }
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -719,12 +719,7 @@ impl<T, const N: usize> StaticVec<T, N> {
   #[inline(always)]
   pub fn iter(&self) -> StaticVecIterConst<T, N> {
     StaticVecIterConst {
-      start: self.as_ptr(),
-      end: match intrinsics::size_of::<T>() {
-        0 => (self.as_ptr() as *const u8).wrapping_add(self.length) as *const T,
-        _ => unsafe { self.ptr_at_unchecked(self.length) },
-      },
-      marker: PhantomData,
+      iter: slice_from_raw_parts(self.as_ptr(), self.length).iter(),
     }
   }
 
@@ -1192,12 +1187,7 @@ impl<T, const N: usize> StaticVec<T, N> {
         start: end,
         length: length - end,
         iter: StaticVecIterConst {
-          start: self.ptr_at_unchecked(start),
-          end: match intrinsics::size_of::<T>() {
-            0 => (self.as_ptr() as *const u8).wrapping_add(end) as *const T,
-            _ => self.ptr_at_unchecked(end),
-          },
-          marker: PhantomData,
+          iter: slice_from_raw_parts(self.ptr_at_unchecked(start), end - start).iter(),
         },
         vec: self,
       }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,20 +1,7 @@
 use crate::StaticVec;
 use core::cmp::{Ordering, PartialOrd};
-use core::intrinsics;
 use core::mem::MaybeUninit;
 use core::ptr;
-
-/// An internal function for calculating pointer offsets as usizes, while accounting
-/// directly for possible ZSTs. This is used specifically in the iterator implementations.
-#[inline(always)]
-pub(crate) const fn distance_between<T>(dest: *const T, origin: *const T) -> usize {
-  match intrinsics::size_of::<T>() {
-    0 => unsafe { (dest as usize).wrapping_sub(origin as usize) },
-    // Safety: this function is used strictly with linear inputs
-    // where dest is known to come after origin.
-    _ => unsafe { intrinsics::ptr_offset_from(dest, origin) as usize },
-  }
-}
 
 /// A simple reversal function that returns a new array, called in
 /// [`StaticVec::reversed`](crate::StaticVec::reversed).


### PR DESCRIPTION
I changed `StaticVecIterConst` and `StaticVecIterMut` to wrap slice iterators, which we can forward all iterator methods to rather than having to implement everything manually, which gets rid of a lot of `unsafe`.

This change also led me to fix a soundness issue with `StaticVecIterMut::as_slice` – this now returns a `&[T]` with the lifetime of `&self` rather than `'a`, so this illegal code no longer compiles:
```rust
let mut vec = staticvec![1, 2, 3];
let mut iter = vec.iter_mut();
let slice = iter.as_slice();
dbg!(slice); // [1, 2, 3]
*iter.next().unwrap() = 0;
dbg!(slice); // [0, 2, 3]
```

But we can't merge this yet, for two reasons:
- I wasn't sure what to do with the `bounds_to_string` methods, so I removed them for now. Don't they already read potentially uninitialized memory when this method is called on an empty iterator? I'm not sure what purpose this method solves if the `Debug` implementation already shows the entire slice.
- `slice::Iter::as_slice` and `slice::IterMut::as_slice` aren't currently `const`, so I'll have to submit a PR to the Rust repo to make those `const` before I can make the `as_slice` methods here `const` again.