### PR TITLE
Fix overly cautious assert in Index<Range<>> and IndexMut<Range<>>

### DIFF
--- a/src/trait_impls.rs
+++ b/src/trait_impls.rs
@@ -516,7 +516,7 @@ impl<T, const N: usize> Index<Range<usize>> for StaticVec<T, N> {
   /// and if so returns a constant reference to a slice of elements `index.start..index.end`.
   #[inline(always)]
   fn index(&self, index: Range<usize>) -> &Self::Output {
-    assert!(index.start < index.end && index.end <= self.length);
+    assert!(index.start <= index.end && index.end <= self.length);
     slice_from_raw_parts(
       unsafe { self.ptr_at_unchecked(index.start) },
       index.end - index.start,
@@ -530,7 +530,7 @@ impl<T, const N: usize> IndexMut<Range<usize>> for StaticVec<T, N> {
   /// and if so returns a mutable reference to a slice of elements `index.start..index.end`.
   #[inline(always)]
   fn index_mut(&mut self, index: Range<usize>) -> &mut Self::Output {
-    assert!(index.start < index.end && index.end <= self.length);
+    assert!(index.start <= index.end && index.end <= self.length);
     slice_from_raw_parts_mut(
       unsafe { self.mut_ptr_at_unchecked(index.start) },
       index.end - index.start,

--- a/test/test_staticvec.rs
+++ b/test/test_staticvec.rs
@@ -2052,6 +2052,15 @@ fn try_push() {
   assert_eq!(vec2, [1, 2, 3, 3]);
 }
 
+#[test]
+fn empty_slice() {
+  let mut vec = staticvec![1, 2, 3, 4, 5];
+  let s = &vec[0..0];
+  assert_eq!(0, s.len());
+  let s = &mut vec[0..0];
+  assert_eq!(0, s.len());
+}
+
 /*
 #[test]
 fn union() {


### PR DESCRIPTION
It is perfectly legal to have std::ops::Range with a start equal an end. The
length of such range is zero.  Example: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=3ccc1c83e2e26352a6b0cdc815f23ad4

While empty slice might be looking useless, it helps to avoid
special-casing in code like this:

for x in &vec[start..end] { ... }