### PR TITLE
Add `const_saturating_int_methods` feature dependency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@
   const_ptr_offset_from,
   const_raw_ptr_deref,
   const_raw_ptr_to_usize_cast,
+  const_saturating_int_methods,
   const_trait_impl,
   core_intrinsics,
   doc_cfg,


### PR DESCRIPTION
Compilation error on currently nightly seemed to indicate the `const_saturating_int_methods` feature flag was required; compiles successfully after flag was added.