### PR TITLE
Add feature gate needed for latest nightly.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@
   const_ptr_offset_from,
   const_raw_ptr_deref,
   const_raw_ptr_to_usize_cast,
+  const_saturating_int_methods,
   const_trait_impl,
   core_intrinsics,
   doc_cfg,


### PR DESCRIPTION
Hey, it's me with latest nightly breakage again :)
Added a feature gate that allows `staticvec` to be built on the latest nightly version of `rustc`.