### PR TITLE
Use `MaybeUninit::assume_init_read` instead of `read`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1768,7 +1768,7 @@ impl<T, const N: usize> StaticVec<T, N> {
       // Set the length of `self` to 0 to prevent double-drops.
       self.length = 0;
       // Read out the contents of `data`.
-      unsafe { Ok(self.data.read()) }
+      unsafe { Ok(self.data.assume_init_read()) }
     }
   }
 


### PR DESCRIPTION
This method has been renamed from `MaybeUninit::read`.
Fixes issue #42.